### PR TITLE
Added float intrinsics for x86 & ARMV8.

### DIFF
--- a/essim/essim.h
+++ b/essim/essim.h
@@ -43,11 +43,11 @@ typedef enum eSSIMMode {
 
   /* performance integer implementation. the function is bit-exact as one in
      SSIM_MODE_REF, but it has a lot of optimizations. */
-  SSIM_MODE_PERF_INT = 1,
+  SSIM_MODE_INT = 1,
 
   /* performance float implementation. the functions has more optimization.
      results on different platforms may vary. */
-  SSIM_MODE_PERF_FLOAT = 2
+  SSIM_MODE_PERF = 2
 } eSSIMMode;
 
 typedef enum eSSIMFlags {

--- a/essim/inc/internal.h
+++ b/essim/inc/internal.h
@@ -297,6 +297,17 @@ void sum_windows_8x8_int_10u(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x4_int_10u(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x8_int_10u(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x16_int_10u(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x8_float_8u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_8u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_8u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_8u(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x4_float_10u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_8x8_float_10u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_10u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_10u(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_10u(SUM_WINDOWS_FORMAL_ARGS);
 #endif
 void sum_windows_float_8u(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_8x4_float_8u(SUM_WINDOWS_FORMAL_ARGS);
@@ -331,6 +342,17 @@ void sum_windows_8x8_int_8u_c(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x4_int_8u_c(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x8_int_8u_c(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x16_int_8u_c(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x8_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x4_float_10u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_8x8_float_10u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_10u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_10u_c(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_10u_c(SUM_WINDOWS_FORMAL_ARGS);
 #endif
 void sum_windows_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_8x4_float_8u_c(SUM_WINDOWS_FORMAL_ARGS);
@@ -370,6 +392,18 @@ void sum_windows_16_int_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x4_int_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x8_int_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x16_int_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x8_float_8u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_8u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_8u_ssse3(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_8u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_8u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x4_float_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_8x8_float_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_10u_avx2(SUM_WINDOWS_FORMAL_ARGS);
 #endif
 
 void sum_windows_8x4_float_8u_ssse3(SUM_WINDOWS_FORMAL_ARGS);
@@ -400,6 +434,19 @@ void sum_windows_16_int_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x4_int_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x8_int_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
 void sum_windows_16x16_int_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x8_float_8u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16_float_8u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_8u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_8u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_8u_neon(SUM_WINDOWS_FORMAL_ARGS);
+
+void sum_windows_8x4_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_8x8_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x4_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x8_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
+void sum_windows_16x16_float_10u_neon(SUM_WINDOWS_FORMAL_ARGS);
 #endif
 
 #endif /* defined(_X86) || defined(_X64) */

--- a/essim/src/ssim_internal.c
+++ b/essim/src/ssim_internal.c
@@ -684,6 +684,42 @@ void sum_windows_12x4_float_8u_c(SUM_WINDOWS_FORMAL_ARGS) {
   sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
 }
 
+void sum_windows_8x8_float_8u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x4_float_8u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x8_float_8u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x16_float_8u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_8x4_float_10u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_8x8_float_10u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x4_float_10u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x8_float_10u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
+void sum_windows_16x16_float_10u_c(SUM_WINDOWS_FORMAL_ARGS) {
+  sum_windows_float_8u_c(SUM_WINDOWS_ACTUAL_ARGS);
+}
+
 void sum_windows_float_16u_c(SUM_WINDOWS_FORMAL_ARGS) {
   const uint32_t windowSizeDiv4 = windowSize / 4;
 

--- a/essim/src/ssim_internal.disp.c
+++ b/essim/src/ssim_internal.disp.c
@@ -91,6 +91,26 @@ IMPL_PROC_1(sum_windows_16x8_int_10u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS), avx2)
 IMPL_PROC_1(sum_windows_16x16_int_10u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+
+IMPL_PROC_1(sum_windows_8x8_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_2(sum_windows_16x4_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), ssse3, avx2)
+IMPL_PROC_1(sum_windows_16x8_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_1(sum_windows_16x16_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+
+IMPL_PROC_1(sum_windows_8x4_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_1(sum_windows_8x8_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_1(sum_windows_16x4_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_1(sum_windows_16x8_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), avx2)
+IMPL_PROC_1(sum_windows_16x16_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), avx2)
 #endif
 IMPL_PROC_1(sum_windows_12x4_int_8u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS), sse41)
@@ -140,6 +160,26 @@ IMPL_PROC_1(sum_windows_16x8_int_10u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS), neon)
 IMPL_PROC_1(sum_windows_16x16_int_10u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS), neon)
+
+IMPL_PROC_1(sum_windows_8x8_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x4_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x8_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x16_float_8u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
+
+IMPL_PROC_1(sum_windows_8x4_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_8x8_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+            (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x4_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x8_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
+IMPL_PROC_1(sum_windows_16x16_float_10u, (SUM_WINDOWS_FORMAL_ARGS),
+           (SUM_WINDOWS_ACTUAL_ARGS), neon)
 #endif
 IMPL_PROC_0(sum_windows_12x4_int_8u, (SUM_WINDOWS_FORMAL_ARGS),
             (SUM_WINDOWS_ACTUAL_ARGS))

--- a/essim/src/ssim_ssim.c
+++ b/essim/src/ssim_ssim.c
@@ -235,9 +235,9 @@ ssim_allocate_ctx_array(const size_t numCtx, const uint32_t width,
     if(windowStride==4)
       printf("\nWARNING : eSSIM precision will be very low\n");
   }
-  eSSIMMode mode = SSIM_MODE_PERF_INT;
+  eSSIMMode mode = SSIM_MODE_INT;
   if(bitDepthMinus8 > 2) {
-    mode = SSIM_MODE_PERF_FLOAT;
+    mode = SSIM_MODE_PERF;
     printf("\nWARNING : Bit-depth > 10 only eSSIM Float is supported\n");
   } else {
     mode = eSSIMmode;
@@ -267,54 +267,64 @@ ssim_allocate_ctx_array(const size_t numCtx, const uint32_t width,
     if (SSIM_DATA_8BIT == dataType) {
       p->params.load_4x4_windows_proc = load_4x4_windows_8u;
       if ((8 == windowSize) && (4 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_8x4_int_8u)
                                          : (sum_windows_8x4_float_8u);
 #if NEW_SIMD_FUNC
       } else if ((8 == windowSize) && (8 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_8x8_int_8u)
-                                         : (sum_windows_float_8u);
+                                         : (sum_windows_8x8_float_8u);
       } else if ((16 == windowSize) && (4 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_16x4_int_8u)
-                                         : (sum_windows_float_8u);
+                                         : (sum_windows_16x4_float_8u);
       } else if ((16 == windowSize) && (8 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_16x8_int_8u)
-                                         : (sum_windows_float_8u);
+                                         : (sum_windows_16x8_float_8u);
       } else if ((16 == windowSize) && (16 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_16x16_int_8u)
-                                         : (sum_windows_float_8u);
+                                         : (sum_windows_16x16_float_8u);
 #endif
       } else if ((12 == windowSize) && (4 == windowStride)) {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_12x4_int_8u)
                                          : (sum_windows_12x4_float_8u);
       } else {
-        p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                          ? (sum_windows_int_8u)
                                          : (sum_windows_float_8u);
       }
 #if NEW_SIMD_FUNC
-    } else if ((bitDepthMinus8 == 2) && (SSIM_MODE_PERF_INT == mode)) {
+    } else if (bitDepthMinus8 == 2) {
       p->params.load_4x4_windows_proc = load_4x4_windows_10u;
       if ((8 == windowSize) && (4 == windowStride)) {
-        p->params.sum_windows_proc = sum_windows_8x4_int_10u;
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
+                                         ? (sum_windows_8x4_int_10u)
+                                         : (sum_windows_8x4_float_10u);
       } else if ((8 == windowSize) && (8 == windowStride)) {
-        p->params.sum_windows_proc = sum_windows_8x8_int_10u;
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
+                                         ? (sum_windows_8x8_int_10u)
+                                         : (sum_windows_8x8_float_10u);
       } else if ((16 == windowSize) && (4 == windowStride)) {
-        p->params.sum_windows_proc = sum_windows_16x4_int_10u;
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
+                                         ? (sum_windows_16x4_int_10u)
+                                         : (sum_windows_16x4_float_10u);
       } else if ((16 == windowSize) && (8 == windowStride)) {
-        p->params.sum_windows_proc = sum_windows_16x8_int_10u;
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
+                                         ? (sum_windows_16x8_int_10u)
+                                         : (sum_windows_16x8_float_10u);
       } else if ((16 == windowSize) && (16 == windowStride)) {
-        p->params.sum_windows_proc = sum_windows_16x16_int_10u;
+        p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
+                                         ? (sum_windows_16x16_int_10u)
+                                         : (sum_windows_16x16_float_10u);
       }
 #endif
     } else {
     p->params.load_4x4_windows_proc = load_4x4_windows_16u;
-    p->params.sum_windows_proc = (SSIM_MODE_PERF_INT == mode)
+    p->params.sum_windows_proc = (SSIM_MODE_INT == mode)
                                        ? (sum_windows_int_16u)
                                        : (sum_windows_float_16u);
     }
@@ -347,7 +357,7 @@ ssim_allocate_ctx_array(const size_t numCtx, const uint32_t width,
 
   const uint64_t MAX_SSIM_ACCUMULATED_SUM_VALUE
                  = essim_mink_value == 4 ? 18446744073709551615U : (uint64_t)1 << 63;
-  if(mode != SSIM_MODE_PERF_FLOAT) {
+  if(mode != SSIM_MODE_PERF) {
     /*generating LUT to avoid final stage division in cal window for ssim_val*/
     div_lookup_ptr = div_lookup_generator();
     uint32_t numWindows = GetTotalWindows(width, height, windowSize, windowStride);
@@ -453,7 +463,7 @@ eSSIMResult ssim_aggregate_score(float *const pSsimScore,
     return SSIM_ERR_NULL_PTR;
   }
 
-  if (SSIM_MODE_PERF_FLOAT == ctxa->params.mode) {
+  if (SSIM_MODE_PERF == ctxa->params.mode) {
     double ssim_sum = 0.0f;
     double ssim_mink_sum = 0.0f;
     size_t numWindows = 0;

--- a/ffmpeg/vf_essim.c
+++ b/ffmpeg/vf_essim.c
@@ -71,10 +71,10 @@ typedef struct ESSIMContext {
 static const AVOption essim_options[] = {
     { "stats_file", "file where to store per-frame difference information", OFFSET(stats_file_str), AV_OPT_TYPE_STRING, {.str=NULL}, 0, 0, FLAGS },
 
-    { "mode",  "mode of operation to trade off between performance and cross-platform precision", OFFSET(mode), AV_OPT_TYPE_INT,   { .i64 = SSIM_MODE_PERF_INT }, 0, 2, FLAGS, "mode" },
+    { "mode",  "mode of operation to trade off between performance and cross-platform precision", OFFSET(mode), AV_OPT_TYPE_INT,   { .i64 = SSIM_MODE_PERF }, 0, 2, FLAGS, "mode" },
     { "ref",   "reference integer implementation with few optimizations",                         0,            AV_OPT_TYPE_CONST, { .i64 = SSIM_MODE_REF }, INT_MIN, INT_MAX, FLAGS, "mode" },
-    { "int",   "optimized integer implementation, bit-exact to reference",                        0,            AV_OPT_TYPE_CONST, { .i64 = SSIM_MODE_PERF_INT }, INT_MIN, INT_MAX, FLAGS, "mode" },
-    { "float", "optimized float implementation, not bit-exact to reference",                      0,            AV_OPT_TYPE_CONST, { .i64 = SSIM_MODE_PERF_FLOAT }, INT_MIN, INT_MAX, FLAGS, "mode" },
+    { "int",   "optimized integer implementation, bit-exact to reference",                        0,            AV_OPT_TYPE_CONST, { .i64 = SSIM_MODE_INT }, INT_MIN, INT_MAX, FLAGS, "mode" },
+    { "perf", "best performance mode, not bit-exact to reference",                      0,            AV_OPT_TYPE_CONST, { .i64 = SSIM_MODE_PERF }, INT_MIN, INT_MAX, FLAGS, "mode" },
 
     { "mink",  "minkowski pooling coefficient", OFFSET(essim_mink_value), AV_OPT_TYPE_INT,   { .i64 = 3 }, 3, 4, FLAGS },
 

--- a/test/test_ssim_ssim.cpp
+++ b/test/test_ssim_ssim.cpp
@@ -150,7 +150,7 @@ TEST(ssimTest, threading) {
         float ssimRef = 0;
         auto resRef = ssim_compute_8u(&ssimRef, &essimRef, pRef, refStride, pCmp,
                                       cmpStride, width, height, windowSize,
-                                      windowStride, 1, SSIM_MODE_PERF_INT,
+                                      windowStride, 1, SSIM_MODE_INT,
                                       SSIM_SPATIAL_POOLING_MINK,
                                       essim_mink_value);
         // call and test threaded versions
@@ -160,7 +160,7 @@ TEST(ssimTest, threading) {
           float essimTst = 0;
           auto resTst = ssim_compute_threaded(
               &ssimTst, &essimTst, pRef, refStride, pCmp, cmpStride, width, height,
-              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_INT,
               SSIM_SPATIAL_POOLING_MINK, numThreads);
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
           ASSERT_EQ(resRef, resTst);
@@ -207,7 +207,7 @@ TEST(ssimTest, threading_10bit) {
         float essimRef = 0 ;
         auto resRef = ssim_compute_16u(
             &ssimRef, &essimRef, pRef, refStride, pCmp, cmpStride, width, height,
-            bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+            bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_INT,
             SSIM_SPATIAL_POOLING_MINK, essim_mink_value);
         // call and test threaded versions
         for (uint32_t numThreads = 1; numThreads < MAX_NUM_THREADS;
@@ -216,7 +216,7 @@ TEST(ssimTest, threading_10bit) {
           float essimTst = 0;
           auto resTst = ssim_compute_threaded(
               &ssimTst, &essimTst, pRef, refStride, pCmp, cmpStride, width, height,
-              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_INT,
               SSIM_SPATIAL_POOLING_MINK, numThreads);
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
           ASSERT_EQ(resRef, resTst);
@@ -277,7 +277,7 @@ TEST(ssimTest, threading) {
         float ssimRefInt = 0;
         auto resRefInt = ssim_compute_8u(
             &ssimRefInt, &essimRefInt, pRef, refStride, pCmp, cmpStride, width,
-            height, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+            height, windowSize, windowStride, 1, SSIM_MODE_INT,
             SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
         std::cout << "ssimRef_Int : " << (float)ssimRefInt
                   << " essimRef_Int : " << (float)essimRefInt << std::endl;
@@ -295,7 +295,7 @@ TEST(ssimTest, threading) {
                     auto resRefFloat = ssim_compute_8u(
                         &ssimRefFloat, &essimRefFloat, pRef, refStride, pCmp,
                         cmpStride, width, height, windowSize, windowStride, 1,
-                        SSIM_MODE_PERF_FLOAT, SSIM_SPATIAL_POOLING_BOTH,
+             SSIM_MODE_PERF, SSIM_SPATIAL_POOLING_BOTH,
                         essim_mink_value);
                     std::cout << "ssimRefFloat : " << (float)ssimRefFloat <<  " essimRefFloat : "
                   << (float)essimRefFloat << std::endl;
@@ -311,7 +311,7 @@ TEST(ssimTest, threading) {
           float essimTst = 0;
           auto resTst = ssim_compute_threaded(
               &ssimTst, &essimTst, pRef, refStride, pCmp, cmpStride, width, height,
-              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_INT,
               SSIM_SPATIAL_POOLING_BOTH, numThreads);
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
           ASSERT_EQ(resRefInt, resTst);
@@ -377,7 +377,7 @@ TEST(ssimTest, threading_10bit) {
         auto resRefInt = ssim_compute_16u(
             &ssimRefInt, &essimRefInt, pRef, refStride, pCmp, cmpStride, width,
             height, bitDepthMinus8, windowSize, windowStride, 1,
-            SSIM_MODE_PERF_INT, SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
+            SSIM_MODE_INT, SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
         std::cout << "ssimRef_Int : " << (float)ssimRefInt
                   << " essimRef_Int : " << (float)essimRefInt << std::endl;
 #if PROFILING_PRINTS
@@ -394,7 +394,7 @@ TEST(ssimTest, threading_10bit) {
         auto resRefFloat = ssim_compute_16u(
             &ssimRefFloat, &essimRefFloat, pRef, refStride, pCmp, cmpStride,
             width, height, bitDepthMinus8, windowSize, windowStride, 1,
-            SSIM_MODE_PERF_FLOAT, SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
+            SSIM_MODE_PERF, SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
         std::cout << "ssimRefFloat : " << (float)ssimRefFloat <<  " essimRefFloat : "
                   << (float)essimRefFloat << std::endl;
 #if PROFILING_PRINTS
@@ -409,7 +409,7 @@ TEST(ssimTest, threading_10bit) {
           float essimTst = 0;
           auto resTst = ssim_compute_threaded(
               &ssimTst, &essimTst, pRef, refStride, pCmp, cmpStride, width, height,
-              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_PERF_INT,
+              bitDepthMinus8, windowSize, windowStride, 1, SSIM_MODE_INT,
               SSIM_SPATIAL_POOLING_BOTH, numThreads);
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
           ASSERT_EQ(resRefInt, resTst);

--- a/yuvtestsuite/gtest_main.cc
+++ b/yuvtestsuite/gtest_main.cc
@@ -79,8 +79,8 @@ void print_help() {
   printf(" -mink : SSIM Minkowski pooling (can be 3 or 4).Default is 4. \n");
   /*Currently not supporting essimmode as user argument,
   because at frame level we need both INT and Float eSSIM values. */
-  /*printf(" -mode : Can be 0 -> SSIM_MODE_REF, 1 -> SSIM_MODE_PERF_INT,
-  2 -> SSIM_MODE_PERF_FLOAT. Default is 1 \n"); */
+  /*printf(" -mode : Can be 0 -> SSIM_MODE_REF, 1 -> SSIM_MODE_INT,
+  2 -> SSIM_MODE_PERF. Default is 1 \n"); */
   printf("\n Example cmd : \t");
   printf(" -r /mnt/d/InpYuvPath/xyz.yuv -d /mnt/d/ReconYuvPath/abc.yuv \
   -w 1280 -h 720 -bd 10 -wsize 16 -wstride 8 -mink 3\n");
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
         Mode = atoi(argv[++i]);
         if(Mode != 0 && Mode != 1 && Mode != 2) {
           Mode = 1;
-          std::cout << "Considering default eSSIMMode i.e 1 (SSIM_MODE_PERF_INT)"
+          std::cout << "Considering default eSSIMMode i.e 1 (SSIM_MODE_INT)"
                     << std::endl;
         }
       }
@@ -167,9 +167,9 @@ int main(int argc, char **argv) {
   if(Mode == 0)
     ModeEnum = SSIM_MODE_REF;
   else if (Mode == 2)
-    ModeEnum = SSIM_MODE_PERF_FLOAT;
+    ModeEnum = SSIM_MODE_PERF;
   else
-    ModeEnum = SSIM_MODE_PERF_INT;
+    ModeEnum = SSIM_MODE_INT;
 
   if(ModeEnum == SSIM_MODE_REF) {
     std::cout << "currently not supporting at frame level" << std::endl;
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
 #endif
       ssim_compute_8u(&FrSSIMScore_Int, &FrESSIMScore_Int, InpYuvBuff, stride,
                                       ReconYuvBuff, stride, Width, Height, WSize,
-                                      WStride, 1, SSIM_MODE_PERF_INT,
+                                      WStride, 1, SSIM_MODE_INT,
                                       SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
 #if PROFILING_PRINTS
         end = clock();
@@ -315,7 +315,7 @@ int main(int argc, char **argv) {
 #endif
       ssim_compute_8u(&FrSSIMScore_float, &FrESSIMScore_float, InpYuvBuff, stride,
                                       ReconYuvBuff, stride, Width, Height, WSize,
-                                      WStride, 1, SSIM_MODE_PERF_FLOAT,
+                                      WStride, 1, SSIM_MODE_PERF,
                                       SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
 #if PROFILING_PRINTS
         end = clock();
@@ -335,7 +335,7 @@ int main(int argc, char **argv) {
 #endif
       ssim_compute_16u(&FrSSIMScore_Int, &FrESSIMScore_Int, InpYuvBuffHbd, stride,
                                       ReconYuvBuffHbd, stride, Width, Height, BitDepthMinus8,
-                                      WSize, WStride, 1, SSIM_MODE_PERF_INT,
+                                      WSize, WStride, 1, SSIM_MODE_INT,
                                       SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
 #if PROFILING_PRINTS
         end = clock();
@@ -347,7 +347,7 @@ int main(int argc, char **argv) {
 #endif
       ssim_compute_16u(&FrSSIMScore_float, &FrESSIMScore_float, InpYuvBuffHbd, stride,
                                       ReconYuvBuffHbd, stride, Width, Height, BitDepthMinus8,
-                                      WSize, WStride, 1, SSIM_MODE_PERF_FLOAT,
+                                      WSize, WStride, 1, SSIM_MODE_PERF,
                                       SSIM_SPATIAL_POOLING_BOTH, essim_mink_value);
 #if PROFILING_PRINTS
         end = clock();


### PR DESCRIPTION
Added float intrinsics for x86 & ARMV8.
Renamed SSIM_MODE_PERF_INT as SSIM_MODE_INT & SSIM_MODE_PERF_FLOAT as SSIM_MODE_PERF.
In FFMPEG plugin, default mode is set to SSIM_MODE_PERF.